### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM jwilder/nginx-proxy
+FROM jwilder/nginx-proxy:latest
 
 LABEL maintainer="Boudy de Geer"
 LABEL project="space-station"


### PR DESCRIPTION
`jwilder/nginx-proxy` changed recently. This pull request ensures you're using the latest version of the image and changes `jwilder/nginx-proxy` to the latest tag: `latest`

New base image: `jwilder/nginx-proxy:latest`